### PR TITLE
ツリービューを動的に更新する

### DIFF
--- a/src/CVarinfoText.cpp
+++ b/src/CVarinfoText.cpp
@@ -74,6 +74,22 @@ void CVarinfoText::addVar( PVal* pval, char const* name )
 }
 
 //------------------------------------------------
+// 値データから生成
+//------------------------------------------------
+void CVarinfoText::addValue(char const* name, PDAT const* pdat, vartype_t vtype)
+{
+	getWriter().catln(strf("[%s]", name));
+	getWriter().catln(strf("変数型: %s", hpiutil::varproc(vtype)->vartype_name));
+	if ( g_config->showsVariableAddress ) {
+		getWriter().catln(strf("アドレス: %p", static_cast<void const*>(pdat)));
+	}
+	getWriter().catCrlf();
+
+	CVardataStrWriter::create<CTreeformedWriter>(getBuf())
+		.addValue(name, vtype, pdat);
+}
+
+//------------------------------------------------
 // システム変数データから生成
 //------------------------------------------------
 void CVarinfoText::addSysvar(hpiutil::Sysvar::Id id)

--- a/src/CVarinfoText.h
+++ b/src/CVarinfoText.h
@@ -19,6 +19,7 @@ public:
 	CVarinfoText();
 
 	void addVar(PVal* pval, char const* name);
+	void addValue(char const* name, PDAT const* pdat, vartype_t vtype);
 	void addSysvar(hpiutil::Sysvar::Id id);
 #ifdef with_WrapCall
 	void addCall(WrapCall::ModcmdCallInfo const& callinfo);

--- a/src/VTNodeModule.cpp
+++ b/src/VTNodeModule.cpp
@@ -127,14 +127,14 @@ void VTNodeModule::foreach(VTNodeModule::Visitor const& visitor) const
 //------------------------------------------------
 // 更新
 //------------------------------------------------
-bool VTNodeModule::updateSub(bool deep)
+bool VTNodeModule::updateSub(int nest)
 {
-	if ( deep ) {
+	if ( nest > 0 ) {
 		for ( auto const& kv : p_->modules_ ) {
-			kv.second->updateDownDeep();
+			kv.second->updateDown(nest - 1);
 		}
 		for ( auto const& kv : p_->vars_ ) {
-			kv.second->updateDownDeep();
+			kv.second->updateDown(nest - 1);
 		}
 	}
 	return true;

--- a/src/VTNodeVar.cpp
+++ b/src/VTNodeVar.cpp
@@ -3,6 +3,46 @@
 #include "VarTreeNodeData.h"
 #include "module/strf.h"
 
+bool VTNodeVar::updateSub(bool deep)
+{
+	if ( deep ) {
+		// 型が変わるか、要素数が減るか、低次元の要素数が増えたなら、再構築を行う
+		if ( pval_->flag != pvalBak_.flag
+			|| memcmp(&pvalBak_.len[1], &pval_->len[1], hpiutil::ArrayDimMax * sizeof(int))
+				> 0
+			) {
+			children_.clear();
+		}
+
+		// 既存要素は更新し、新規要素は挿入する
+		{
+			size_t const oldLen = children_.size();
+			size_t const newLen = hpiutil::PVal_cntElems(pval_);
+
+			for ( size_t i = 0; i < newLen; i++ ) {
+				PDAT const* const pdat = hpiutil::PVal_getPtr(pval_, i);
+
+				if ( i < oldLen ) {
+					children_[i]->resetPtr(pdat);
+
+				} else {
+					auto&& name =
+						hpiutil::stringifyArrayIndex(hpiutil::PVal_indexesFromAptr(pval_, i));
+
+					children_.emplace_back(std::make_shared<VTNodeValue>
+						( this, std::move(name)
+						, pdat, pval_->flag
+						));
+				}
+
+				children_[i]->updateDownDeep();
+			}
+		}
+	}
+	pvalBak_ = *pval_;
+	return true;
+}
+
 void VTNodeVector::addChild(int i)
 {
 	if ( dimIndex_ == 0 ) {

--- a/src/VTNodeVar.cpp
+++ b/src/VTNodeVar.cpp
@@ -3,9 +3,9 @@
 #include "VarTreeNodeData.h"
 #include "module/strf.h"
 
-bool VTNodeVar::updateSub(bool deep)
+bool VTNodeVar::updateSub(int nest)
 {
-	if ( deep ) {
+	if ( nest > 0 ) {
 		// Œ^‚ª•Ï‚í‚é‚©A—v‘f”‚ªŒ¸‚é‚©A’áŸŒ³‚Ì—v‘f”‚ª‘‚¦‚½‚È‚çAÄ\’z‚ğs‚¤
 		if ( pval_->flag != pvalBak_.flag
 			|| memcmp(&pvalBak_.len[1], &pval_->len[1], hpiutil::ArrayDimMax * sizeof(int))
@@ -35,7 +35,7 @@ bool VTNodeVar::updateSub(bool deep)
 						));
 				}
 
-				children_[i]->updateDownDeep();
+				children_[i]->updateDown(nest - 1);
 			}
 		}
 	}
@@ -58,9 +58,9 @@ void VTNodeVector::addChild(int i)
 	}
 }
 
-bool VTNodeVector::updateSub(bool deep)
+bool VTNodeVector::updateSub(int nest)
 {
-	if ( deep ) {
+	if ( nest > 0 ) {
 		int const newLen = pval_->len[1 + dimIndex_];
 
 		// var ‚Ìqƒm[ƒhŠÇ—‚Ìd‘g‚İ‚É‚æ‚èA‚±‚ê‚Ì—v‘f”‚ªŒ¸‚Á‚½‚èAŒ^‚ª•Ï‚í‚é‚±‚Æ‚Í‚ ‚è‚¦‚È‚¢
@@ -72,7 +72,7 @@ bool VTNodeVector::updateSub(bool deep)
 		}
 
 		for ( auto& e : children_ ) {
-			e->updateDownDeep();
+			e->updateDown(nest - 1);
 		}
 	}
 	return true;

--- a/src/VTNodeVar.cpp
+++ b/src/VTNodeVar.cpp
@@ -1,0 +1,39 @@
+
+#include "main.h"
+#include "VarTreeNodeData.h"
+#include "module/strf.h"
+
+void VTNodeVector::addChild(int i)
+{
+	if ( dimIndex_ == 0 ) {
+		// TODO: 分かりやすい名前をつける
+		auto&& name = strf("(%d)", i);
+
+		children_.emplace_back(std::make_shared<VTNodeValue>
+			( this, std::move(name)
+			, hpiutil::PVal_getPtr(pval_, aptr_ + i), pval_->flag
+			));
+	} else {
+		// TODO: 多次元配列を実装
+	}
+}
+
+bool VTNodeVector::updateSub(bool deep)
+{
+	if ( deep ) {
+		int const newLen = pval_->len[1 + dimIndex_];
+
+		// var の子ノード管理の仕組みにより、これの要素数が減ったり、型が変わることはありえない
+		// (そうなったらこれ自体が破棄される)
+		assert(len_ <= newLen);
+
+		for ( int i = len_; i < newLen; i++ ) {
+			addChild(i);
+		}
+
+		for ( auto& e : children_ ) {
+			e->updateDownDeep();
+		}
+	}
+	return true;
+}

--- a/src/VarTreeNodeData.cpp
+++ b/src/VarTreeNodeData.cpp
@@ -57,11 +57,11 @@ auto VTNodeSysvarList::parent() const -> optional_ref<VTNodeData>
 	return &VTRoot::instance();
 }
 
-bool VTNodeSysvarList::updateSub(bool deep)
+bool VTNodeSysvarList::updateSub(int nest)
 {
-	if ( deep ) {
+	if ( nest > 0 ) {
 		for ( auto&& sysvar : sysvarList() ) {
-			sysvar->updateDownDeep();
+			sysvar->updateDown(nest - 1);
 		}
 	}
 	return true;
@@ -103,14 +103,14 @@ void VTNodeDynamic::eraseLastInvokeNode()
 	children_.pop_back();
 }
 
-bool VTNodeDynamic::updateSub(bool deep)
+bool VTNodeDynamic::updateSub(int nest)
 {
-	if ( deep ) {
+	if ( nest > 0 ) {
 		for ( auto& e : children_ ) {
-			e->updateDownDeep();
+			e->updateDown(nest - 1);
 		}
 		if ( independedResult_ ) {
-			independedResult_->updateDownDeep();
+			independedResult_->updateDown(nest - 1);
 		}
 	}
 	return true;
@@ -161,11 +161,11 @@ void VTNodeInvoke::addResultDepended(unique_ptr<ResultNodeData> result)
 	results_.emplace_back(std::move(result));
 }
 
-bool VTNodeInvoke::updateSub(bool deep)
+bool VTNodeInvoke::updateSub(int nest)
 {
-	if ( deep ) {
+	if ( nest > 0 ) {
 		for ( auto& e : results_ ) {
-			e->updateDownDeep();
+			e->updateDown(nest - 1);
 		}
 	}
 	return true;
@@ -243,11 +243,11 @@ auto VTRoot::children() -> std::vector<std::reference_wrapper<VTNodeData>> const
 	return stt_children;
 }
 
-bool VTRoot::updateSub(bool deep)
+bool VTRoot::updateSub(int nest)
 {
-	if ( deep && p_ ) {
+	if ( nest > 0 && p_ ) {
 		for ( auto const& node : children() ) {
-			node.get().updateDownDeep();
+			node.get().updateDown(nest - 1);
 		}
 	}
 	return true;

--- a/src/VarTreeNodeData.h
+++ b/src/VarTreeNodeData.h
@@ -34,6 +34,38 @@ public:
 	void acceptVisitor(Visitor& visitor) const override { visitor.fVar(*this); }
 };
 
+class VTNodeValue
+	: public VTNodeData
+{
+	VTNodeData* const parent_;
+	string const name_;
+	PDAT const* pdat_;
+	vartype_t const vtype_;
+
+public:
+	VTNodeValue(VTNodeData* parent, string const& name, PDAT const* pdat, vartype_t vtype)
+		: parent_(parent), name_(name), vtype_(vtype)
+	{
+		resetPtr(pdat);
+	}
+
+	auto name() const -> string override { return name_; }
+	auto data() const -> PDAT const* { return pdat_; }
+	auto vartype() const -> vartype_t { return vtype_; }
+	auto parent() const -> optional_ref<VTNodeData> override
+	{
+		return parent_;
+	}
+
+	void resetPtr(PDAT const* pdat)
+	{
+		assert(pdat != nullptr);
+		pdat_ = pdat;
+	}
+
+	void acceptVisitor(Visitor& visitor) const override { visitor.fValue(*this); }
+};
+
 class VTNodeSysvar
 	: public VTNodeData
 {

--- a/src/VarTreeNodeData.h
+++ b/src/VarTreeNodeData.h
@@ -34,6 +34,43 @@ public:
 	void acceptVisitor(Visitor& visitor) const override { visitor.fVar(*this); }
 };
 
+class VTNodeVector
+	: public VTNodeData
+{
+	VTNodeData* const parent_;
+	string const name_;
+
+	PVal* const pval_;
+	int dimIndex_;
+	APTR aptr_;
+	int len_;
+	vector<shared_ptr<VTNodeData>> children_;
+
+public:
+	VTNodeVector(VTNodeData* parent, string const& name, PVal* pval, int dimIndex, APTR aptr)
+		: parent_(parent), name_(name), pval_(pval), dimIndex_(dimIndex)
+		, aptr_(aptr)
+		, len_(pval->len[1 + dimIndex])
+	{
+		assert(0 <= dimIndex && dimIndex < hpiutil::ArrayDimMax);
+	}
+
+	auto name() const -> string override { return name_; }
+	auto parent() const -> optional_ref<VTNodeData> override
+	{
+		return parent_;
+	}
+	int dimIndex() const { return dimIndex_; }
+	int len() const { return len_; }
+
+	void acceptVisitor(Visitor& visitor) const override { visitor.fVector(*this); }
+
+protected:
+	bool updateSub(bool deep) override;
+private:
+	void addChild(int i);
+};
+
 class VTNodeValue
 	: public VTNodeData
 {

--- a/src/VarTreeNodeData.h
+++ b/src/VarTreeNodeData.h
@@ -38,7 +38,7 @@ public:
 	void acceptVisitor(Visitor& visitor) const override { visitor.fVar(*this); }
 
 protected:
-	bool updateSub(bool deep) override;
+	bool updateSub(int nest) override;
 };
 
 class VTNodeVector
@@ -73,7 +73,7 @@ public:
 	void acceptVisitor(Visitor& visitor) const override { visitor.fVector(*this); }
 
 protected:
-	bool updateSub(bool deep) override;
+	bool updateSub(int nest) override;
 private:
 	void addChild(int i);
 };
@@ -150,7 +150,7 @@ public:
 
 protected:
 	void init() override;
-	bool updateSub(bool deep) override;
+	bool updateSub(int nest) override;
 };
 
 class VTNodeScript
@@ -227,7 +227,7 @@ public:
 
 	auto name() const -> string override;
 	auto parent() const -> optional_ref<VTNodeData> override;
-	bool updateSub(bool deep) override;
+	bool updateSub(int nest) override;
 
 	//foreach
 	struct Visitor
@@ -293,7 +293,7 @@ public:
 	void acceptVisitor(Visitor& visitor) const override { visitor.fDynamic(*this); }
 
 protected:
-	bool updateSub(bool deep) override;
+	bool updateSub(int nest) override;
 };
 
 class VTNodeInvoke
@@ -315,7 +315,7 @@ public:
 
 	void acceptVisitor(Visitor& visitor) const override { visitor.fInvoke(*this); }
 protected:
-	bool updateSub(bool deep) override;
+	bool updateSub(int nest) override;
 };
 
 struct ResultNodeData
@@ -382,7 +382,7 @@ public:
 	auto parent() const -> optional_ref<VTNodeData> override { return nullptr; }
 	void acceptVisitor(Visitor& visitor) const override { visitor.fRoot(*this); }
 protected:
-	bool updateSub(bool deep) override;
+	bool updateSub(int nest) override;
 };
 
 #endif

--- a/src/VarTreeNodeData.h
+++ b/src/VarTreeNodeData.h
@@ -14,11 +14,15 @@ class VTNodeVar
 	string const name_;
 	PVal* const pval_;
 
+	PVal pvalBak_;
+	vector<shared_ptr<VTNodeValue>> children_;
+
 public:
 	VTNodeVar(VTNodeData& parent, string const& name, PVal* pval)
 		: parent_(parent), name_(name), pval_(pval)
 	{
 		assert(pval_);
+		pvalBak_ = *pval_;
 	}
 
 	auto name() const -> string override { return name_; }
@@ -32,6 +36,9 @@ public:
 	}
 
 	void acceptVisitor(Visitor& visitor) const override { visitor.fVar(*this); }
+
+protected:
+	bool updateSub(bool deep) override;
 };
 
 class VTNodeVector

--- a/src/VarTreeNodeData_fwd.h
+++ b/src/VarTreeNodeData_fwd.h
@@ -7,6 +7,7 @@
 class VTRoot;
 class VTNodeModule;
 class VTNodeVar;
+class VTNodeVector;
 class VTNodeValue;
 class VTNodeSysvarList;
 class VTNodeSysvar;
@@ -33,6 +34,7 @@ public:
 		virtual void fRoot      (VTRoot           const&) {}
 		virtual void fModule    (VTNodeModule     const&) {}
 		virtual void fVar       (VTNodeVar        const&) {}
+		virtual void fVector    (VTNodeVector     const&) {}
 		virtual void fValue     (VTNodeValue      const&) {}
 		virtual void fSysvarList(VTNodeSysvarList const&) {}
 		virtual void fSysvar    (VTNodeSysvar     const&) {}

--- a/src/VarTreeNodeData_fwd.h
+++ b/src/VarTreeNodeData_fwd.h
@@ -51,27 +51,25 @@ public:
 	virtual auto name() const -> string { return "(anonymous)"; }
 	virtual auto vartype() const -> vartype_t { return HSPVAR_FLAG_NONE; }
 
-	bool updateShallow()     { return update(true, false); }
-	bool updateDeep()        { return update(true, true); }
-	bool updateDownShallow() { return update(false, false); }
-	bool updateDownDeep()    { return update(false, true); }
+	void updateAll() { update(std::numeric_limits<int>::max()); }
+	bool update(int nest)     { return updateImpl(true, nest); }
+	bool updateDown(int nest) { return updateImpl(false, nest); }
 protected:
 	/**
-	Updates this node.
+	Updates this node and descendants over `nest`-generations.
 	Returns `false` if this node or one of the ancestors has vanished.
 	If `up` is `true`, also updates its parent;
 	otherwise, the parent node is uptodate and still exists.
-	If `deep` is `true`, also updates children.
 	//*/
-	bool update(bool up, bool deep)
+	bool updateImpl(bool up, int nest)
 	{
-		if ( up && parent() && ! parent()->updateShallow() ) return false;
+		if ( up && parent() && ! parent()->update(0) ) return false;
 		if ( uninitialized_ ) { uninitialized_ = false; onInit(); init(); }
-		return updateSub(deep);
+		return updateSub(nest);
 	}
 
 	virtual void init() {}
-	virtual bool updateSub(bool deep) { return true; }
+	virtual bool updateSub(int nest) { return true; }
 	bool uninitialized_;
 
 private:

--- a/src/VarTreeNodeData_fwd.h
+++ b/src/VarTreeNodeData_fwd.h
@@ -7,6 +7,7 @@
 class VTRoot;
 class VTNodeModule;
 class VTNodeVar;
+class VTNodeValue;
 class VTNodeSysvarList;
 class VTNodeSysvar;
 class VTNodeDynamic;
@@ -32,6 +33,7 @@ public:
 		virtual void fRoot      (VTRoot           const&) {}
 		virtual void fModule    (VTNodeModule     const&) {}
 		virtual void fVar       (VTNodeVar        const&) {}
+		virtual void fValue     (VTNodeValue      const&) {}
 		virtual void fSysvarList(VTNodeSysvarList const&) {}
 		virtual void fSysvar    (VTNodeSysvar     const&) {}
 		virtual void fDynamic   (VTNodeDynamic    const&) {}

--- a/src/hpiutil/hpiutil.hpp
+++ b/src/hpiutil/hpiutil.hpp
@@ -164,14 +164,19 @@ static auto PVal_maxDim(PVal const* pval) -> size_t
 	return i;
 }
 
-static auto PVal_cntElems(PVal const* pval) -> size_t
+static auto PVal_cntElems(PVal const* pval, size_t dimIndex) -> size_t
 {
 	auto cnt = size_t { 1 };
-	for ( auto i = size_t { 1 };; ++i ) {
+	for ( auto i = size_t { 1 }; i <= dimIndex; ++i ) {
+		if ( pval->len[i] == 0 ) break;
 		cnt *= pval->len[i];
-		if ( i == ArrayDimMax || pval->len[i + 1] == 0 ) break;
 	}
 	return cnt;
+}
+
+static auto PVal_cntElems(PVal const* pval) -> size_t
+{
+	return PVal_cntElems(pval, ArrayDimMax);
 }
 
 static auto PVal_indexesFromAptr(PVal const* pval, APTR aptr) -> std::vector<int>

--- a/src/knowbug.sln
+++ b/src/knowbug.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "knowbug", "knowbug.vcxproj", "{08B5A2A3-7CE3-4D17-9AAA-F18A5F82F1AC}"
 EndProject

--- a/src/knowbug.vcxproj
+++ b/src/knowbug.vcxproj
@@ -350,6 +350,7 @@ copy $(TargetPath) D:\Tool\hsp\$(TargetFileName)
     <ClCompile Include="vartree.cpp" />
     <ClCompile Include="VarTreeNodeData.cpp" />
     <ClCompile Include="VTNodeScript.cpp" />
+    <ClCompile Include="VTNodeVar.cpp" />
     <ClCompile Include="with_ModPtr.cpp" />
     <ClCompile Include="WrapCall\ModcmdCallInfo.cpp" />
     <ClCompile Include="WrapCall\type_modcmd.cpp" />

--- a/src/knowbug.vcxproj.filters
+++ b/src/knowbug.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClCompile Include="VTNodeLog.cpp">
       <Filter>class</Filter>
     </ClCompile>
+    <ClCompile Include="VTNodeVar.cpp">
+      <Filter>class</Filter>
+    </ClCompile>
     <ClCompile Include="cppformat\format.cc">
       <Filter>module\cppformat</Filter>
     </ClCompile>

--- a/src/vartree.cpp
+++ b/src/vartree.cpp
@@ -86,7 +86,7 @@ VTView::VTView()
 	VTRoot::log().setLogObserver(p_->logObserver_);
 
 	// Initialize tree
-	VTRoot::instance().updateDeep();
+	VTRoot::instance().updateAll();
 
 #ifdef with_WrapCall
 	p_->hNodeDynamic_ = p_->itemFromNode(&VTRoot::dynamic());
@@ -154,7 +154,7 @@ void VTView::update()
 	p_->textCache_.clear();
 
 #ifdef with_WrapCall
-	VTRoot::dynamic().updateDeep();
+	VTRoot::dynamic().updateAll();
 #endif
 
 	Dialog::View::update();
@@ -334,7 +334,7 @@ void VTView::updateViewWindow()
 	auto const hItem = TreeView_GetSelection(hwndVarTree);
 	if ( hItem ) {
 		if ( auto&& node = tryGetNodeData(hItem) ) {
-			node->updateDeep();
+			node->update(2);
 		}
 
 		static auto stt_prevSelection = HTREEITEM { nullptr };

--- a/src/vartree.cpp
+++ b/src/vartree.cpp
@@ -333,6 +333,10 @@ void VTView::updateViewWindow()
 {
 	auto const hItem = TreeView_GetSelection(hwndVarTree);
 	if ( hItem ) {
+		if ( auto&& node = tryGetNodeData(hItem) ) {
+			node->updateDeep();
+		}
+
 		static auto stt_prevSelection = HTREEITEM { nullptr };
 		if ( hItem == stt_prevSelection ) {
 			Dialog::View::saveCurrentCaret();

--- a/src/vartree.cpp
+++ b/src/vartree.cpp
@@ -12,6 +12,7 @@
 #include "vartree.h"
 #include "CVarinfoText.h"
 #include "CVardataString.h"
+#include "module/CStrBuf.h"
 
 #include "WrapCall/WrapCall.h"
 #include "WrapCall/ModcmdCallInfo.h"
@@ -244,6 +245,10 @@ auto VTView::getItemVarText(HTREEITEM hItem) const -> std::shared_ptr<string con
 		void fVar(VTNodeVar const& node) override
 		{
 			varinf.addVar(node.pval(), node.name().c_str());
+		}
+		void fValue(VTNodeValue const& node) override
+		{
+			varinf.addValue(node.name().c_str(), node.data(), node.vartype());
 		}
 		void fSysvarList(VTNodeSysvarList const&) override
 		{


### PR DESCRIPTION
配列の要素やメンバ変数もノードとして表現する。
## 不具合
- 値ノードが更新されないことがある。
  - 条件はいまいち分からない。
- 変数要素ノードを選択しているときに変数が再構築されたとき、要素ノードが破壊されない。
## TODO
- [ ] hpiutil の部分は wip_hpiutil に移動する。
- [ ] マスクつきの添字文字列

``` cpp
/**
dimIndex 番目の次元が i となり、それより低い次元は _ で表示される。
例: dimIndex = 2, i = 3 のとき (_, _, 3)
//*/
static auto maskedIndexString(int dimIndex, int i) -> string;
```
