### PR TITLE
パスの生存検査の高速化

### DIFF
--- a/src/knowbug_core/HspObjectPath.cpp
+++ b/src/knowbug_core/HspObjectPath.cpp
@@ -193,6 +193,10 @@ HspObjectPath::Element::Element(std::shared_ptr<HspObjectPath const> parent, Hsp
 {
 }
 
+auto HspObjectPath::Element::is_alive(HspObjects& objects) const -> bool {
+	return objects.element_path_is_alive(*this);
+}
+
 auto HspObjectPath::Element::child_count(HspObjects& objects) const -> std::size_t {
 	return objects.element_path_to_child_count(*this);
 }
@@ -574,6 +578,10 @@ auto HspObjectPath::as_call_frame() const -> HspObjectPath::CallFrame const& {
 		throw new std::bad_cast{};
 	}
 	return *(HspObjectPath::CallFrame const*)this;
+}
+
+auto HspObjectPath::CallFrame::is_alive(HspObjects& objects) const -> bool {
+	return objects.call_frame_path_is_alive(*this);
 }
 
 auto HspObjectPath::CallFrame::child_count(HspObjects& objects) const -> std::size_t {

--- a/src/knowbug_core/HspObjectPath.cpp
+++ b/src/knowbug_core/HspObjectPath.cpp
@@ -545,27 +545,27 @@ auto HspObjectPath::CallStack::child_at(std::size_t child_index, HspObjects& obj
 	// 逆順
 	auto index = child_count(objects) - 1 - child_index;
 
-	auto&& call_frame_id_opt = objects.call_stack_path_to_call_frame_id_at(*this, index);
-	if (!call_frame_id_opt) {
+	auto&& key_opt = objects.call_stack_path_to_call_frame_key_at(*this, index);
+	if (!key_opt) {
 		assert(false && u8"コールフレームを取得できません");
 		return new_unavailable(to_owned(as_utf8(u8"コールフレームを取得できません")));
 	}
 
-	return new_call_frame(*call_frame_id_opt);
+	return new_call_frame(*key_opt);
 }
 
 // -----------------------------------------------
 // コールフレーム
 // -----------------------------------------------
 
-HspObjectPath::CallFrame::CallFrame(std::shared_ptr<HspObjectPath const> parent, std::size_t call_frame_id)
+HspObjectPath::CallFrame::CallFrame(std::shared_ptr<HspObjectPath const> parent, WcCallFrameKey const& key)
 	: parent_(std::move(parent))
-	, call_frame_id_(call_frame_id)
+	, key_(key)
 {
 }
 
-auto HspObjectPath::new_call_frame(std::size_t call_frame_id) const -> std::shared_ptr<HspObjectPath const> {
-	return std::make_shared<HspObjectPath::CallFrame>(self(), call_frame_id);
+auto HspObjectPath::new_call_frame(WcCallFrameKey const& key) const -> std::shared_ptr<HspObjectPath const> {
+	return std::make_shared<HspObjectPath::CallFrame>(self(), key);
 }
 
 auto HspObjectPath::as_call_frame() const -> HspObjectPath::CallFrame const& {

--- a/src/knowbug_core/HspObjectPath.h
+++ b/src/knowbug_core/HspObjectPath.h
@@ -127,12 +127,12 @@ public:
 		return kind() == other.kind() && does_equal(other) && parent().equals(other.parent());
 	}
 
-	bool is_alive(HspObjects& objects) const {
-		if (kind() == HspObjectKind::Root || kind() == HspObjectKind::Module) {
-			return true;
+	// パスが生存しているかを判定する。
+	virtual auto is_alive(HspObjects& objects) const -> bool {
+		if (!parent().is_alive(objects)) {
+			return false;
 		}
 
-		// FIXME: 効率化 (is_alive)
 		auto sibling_count = parent().child_count(objects);
 		for (auto i = std::size_t{}; i < sibling_count; i++) {
 			auto&& sibling = parent().child_at(i, objects);
@@ -249,6 +249,10 @@ public:
 		return kind() == other.kind();
 	}
 
+	auto is_alive(HspObjects& objects) const -> bool override {
+		return true;
+	}
+
 	auto parent() const -> HspObjectPath const& override;
 
 	auto child_count(HspObjects& objects) const -> std::size_t override;
@@ -282,6 +286,10 @@ public:
 
 	bool does_equal(HspObjectPath const& other) const override {
 		return module_id() == other.as_module().module_id();
+	}
+
+	auto is_alive(HspObjects& objects) const -> bool override {
+		return true;
 	}
 
 	auto parent() const -> HspObjectPath const& override {
@@ -323,6 +331,10 @@ public:
 
 	bool does_equal(HspObjectPath const& other) const override {
 		return static_var_id() == other.as_static_var().static_var_id();
+	}
+
+	auto is_alive(HspObjects& objects) const -> bool override {
+		return true;
 	}
 
 	auto parent() const -> HspObjectPath const& override {
@@ -378,6 +390,8 @@ public:
 	bool does_equal(HspObjectPath const& other) const override {
 		return indexes() == other.as_element().indexes();
 	}
+
+	auto is_alive(HspObjects& objects) const -> bool override;
 
 	auto parent() const -> HspObjectPath const& override {
 		return *parent_;
@@ -710,6 +724,10 @@ public:
 		return true;
 	}
 
+	auto is_alive(HspObjects& objects) const -> bool override {
+		return true;
+	}
+
 	auto parent() const -> HspObjectPath const& override {
 		return *parent_;
 	}
@@ -750,6 +768,10 @@ public:
 		return system_var_kind() == other.as_system_var().system_var_kind();
 	}
 
+	auto is_alive(HspObjects& objects) const -> bool override {
+		return true;
+	}
+
 	auto parent() const -> HspObjectPath const& override {
 		return *parent_;
 	}
@@ -784,6 +806,10 @@ public:
 	}
 
 	bool does_equal(HspObjectPath const& other) const override {
+		return true;
+	}
+
+	auto is_alive(HspObjects& objects) const -> bool override {
 		return true;
 	}
 
@@ -823,6 +849,8 @@ public:
 	bool does_equal(HspObjectPath const& other) const override {
 		return key() == other.as_call_frame().key();
 	}
+
+	auto is_alive(HspObjects& objects) const -> bool override;
 
 	auto parent() const -> HspObjectPath const& override {
 		return *parent_;
@@ -865,6 +893,10 @@ public:
 		return true;
 	}
 
+	auto is_alive(HspObjects& objects) const -> bool override {
+		return true;
+	}
+
 	auto parent() const -> HspObjectPath const& override {
 		return *parent_;
 	}
@@ -902,6 +934,10 @@ public:
 	}
 
 	bool does_equal(HspObjectPath const& other) const override {
+		return true;
+	}
+
+	auto is_alive(HspObjects& objects) const -> bool override {
 		return true;
 	}
 
@@ -946,6 +982,10 @@ public:
 	}
 
 	bool does_equal(HspObjectPath const& other) const override {
+		return true;
+	}
+
+	auto is_alive(HspObjects& objects) const -> bool override {
 		return true;
 	}
 

--- a/src/knowbug_core/HspObjectPath.h
+++ b/src/knowbug_core/HspObjectPath.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include "encoding.h"
 #include "HspTypes.h"
+#include "hsp_wrap_call.h"
 #include "memory_view.h"
 
 class HspObjects;
@@ -216,7 +217,7 @@ public:
 	auto new_call_stack() const -> std::shared_ptr<HspObjectPath const>;
 
 protected:
-	auto new_call_frame(std::size_t call_frame_id) const -> std::shared_ptr<HspObjectPath const>;
+	auto new_call_frame(WcCallFrameKey const& key) const -> std::shared_ptr<HspObjectPath const>;
 
 	auto new_general() const -> std::shared_ptr<HspObjectPath const>;
 
@@ -808,19 +809,19 @@ class HspObjectPath::CallFrame final
 {
 	std::shared_ptr<HspObjectPath const> parent_;
 
-	std::size_t call_frame_id_;
+	WcCallFrameKey key_;
 
 public:
 	using HspObjectPath::new_param;
 
-	CallFrame(std::shared_ptr<HspObjectPath const> parent, std::size_t call_frame_id);
+	CallFrame(std::shared_ptr<HspObjectPath const> parent, WcCallFrameKey const& key);
 
 	auto kind() const -> HspObjectKind override {
 		return HspObjectKind::CallFrame;
 	}
 
 	bool does_equal(HspObjectPath const& other) const override {
-		return call_frame_id() == other.as_call_frame().call_frame_id();
+		return key() == other.as_call_frame().key();
 	}
 
 	auto parent() const -> HspObjectPath const& override {
@@ -833,8 +834,8 @@ public:
 
 	auto name(HspObjects& objects) const -> Utf8String override;
 
-	auto call_frame_id() const -> std::size_t {
-		return call_frame_id_;
+	auto key() const -> WcCallFrameKey {
+		return key_;
 	}
 
 	auto signature(HspObjects& objects) const->std::optional<std::vector<Utf8StringView>>;

--- a/src/knowbug_core/HspObjects.cpp
+++ b/src/knowbug_core/HspObjects.cpp
@@ -556,6 +556,21 @@ auto HspObjects::static_var_path_to_metadata(HspObjectPath::StaticVar const& pat
 	return var_path_to_metadata(path, context()).value_or(HspVarMetadata::none());
 }
 
+auto HspObjects::element_path_is_alive(HspObjectPath::Element const& path) const -> bool {
+	auto pval_opt = path_to_pval(path.parent(), MIN_DEPTH, context());
+	if (!pval_opt) {
+		return false;
+	}
+
+	auto aptr_opt = hsx::element_to_aptr(*pval_opt, path.indexes());
+	if (!aptr_opt) {
+		return false;
+	}
+
+	assert(*aptr_opt < hsx::pval_to_element_count(*pval_opt));
+	return true;
+}
+
 auto HspObjects::element_path_to_child_count(HspObjectPath::Element const& path) const -> std::size_t {
 	return 1;
 }
@@ -943,6 +958,10 @@ auto HspObjects::call_frame_path_to_name(HspObjectPath::CallFrame const& path) c
 	auto struct_dat = call_frame_opt->get().struct_dat();
 	auto name = hsx::struct_to_name(struct_dat, context());
 	return to_utf8(as_hsp(name.value_or(u8"???")));
+}
+
+auto HspObjects::call_frame_path_is_alive(HspObjectPath::CallFrame const& path) const -> bool {
+	return wc_call_frame_get(path.key()).has_value();
 }
 
 auto HspObjects::call_frame_path_to_child_count(HspObjectPath::CallFrame const& path) const -> std::size_t {

--- a/src/knowbug_core/HspObjects.cpp
+++ b/src/knowbug_core/HspObjects.cpp
@@ -382,7 +382,7 @@ static auto path_to_param_stack(HspObjectPath const& path, std::size_t depth, HS
 			return hsx::flex_to_param_stack(*flex_opt, ctx);
 		}
 	case HspObjectKind::CallFrame:
-		return wc_call_frame_to_param_stack(path.as_call_frame().call_frame_id());
+		return wc_call_frame_to_param_stack(path.as_call_frame().key());
 
 	default:
 		assert(false && u8"param_stack が取れるべき");
@@ -928,14 +928,14 @@ auto HspObjects::call_stack_path_to_call_frame_count(HspObjectPath::CallStack co
 	return wc_call_frame_count();
 }
 
-auto HspObjects::call_stack_path_to_call_frame_id_at(HspObjectPath::CallStack const& path, std::size_t call_frame_index) const -> std::optional<std::size_t> {
-	return wc_call_frame_id_at(call_frame_index);
+auto HspObjects::call_stack_path_to_call_frame_key_at(HspObjectPath::CallStack const& path, std::size_t call_frame_index) const -> std::optional<WcCallFrameKey> {
+	return wc_call_frame_key_at(call_frame_index);
 }
 
 namespace hsx = hsp_sdk_ext;
 
 auto HspObjects::call_frame_path_to_name(HspObjectPath::CallFrame const& path) const -> std::optional<Utf8String> {
-	auto&& call_frame_opt = wc_call_frame_get(path.call_frame_id());
+	auto&& call_frame_opt = wc_call_frame_get(path.key());
 	if (!call_frame_opt) {
 		return std::nullopt;
 	}
@@ -970,7 +970,7 @@ auto HspObjects::call_frame_path_to_child_at(HspObjectPath::CallFrame const& pat
 }
 
 auto HspObjects::call_frame_path_to_signature(HspObjectPath::CallFrame const& path) const->std::optional<std::vector<Utf8StringView>> {
-	auto&& call_frame_opt = wc_call_frame_get(path.call_frame_id());
+	auto&& call_frame_opt = wc_call_frame_get(path.key());
 	if (!call_frame_opt) {
 		return std::nullopt;
 	}
@@ -987,7 +987,7 @@ auto HspObjects::call_frame_path_to_signature(HspObjectPath::CallFrame const& pa
 }
 
 auto HspObjects::call_frame_path_to_full_path(HspObjectPath::CallFrame const& path) const -> std::optional<Utf8StringView> {
-	auto&& call_frame_opt = wc_call_frame_get(path.call_frame_id());
+	auto&& call_frame_opt = wc_call_frame_get(path.key());
 	if (!call_frame_opt) {
 		return std::nullopt;
 	}
@@ -1007,7 +1007,7 @@ auto HspObjects::call_frame_path_to_full_path(HspObjectPath::CallFrame const& pa
 }
 
 auto HspObjects::call_frame_path_to_line_index(HspObjectPath::CallFrame const& path) const -> std::optional<std::size_t> {
-	auto&& call_frame_opt = wc_call_frame_get(path.call_frame_id());
+	auto&& call_frame_opt = wc_call_frame_get(path.key());
 	if (!call_frame_opt) {
 		return std::nullopt;
 	}

--- a/src/knowbug_core/HspObjects.h
+++ b/src/knowbug_core/HspObjects.h
@@ -5,6 +5,7 @@
 #include "encoding.h"
 #include "HspTypes.h"
 #include "HspObjectPath.h"
+#include "hsp_wrap_call.h"
 
 class HspDebugApi;
 class HspStaticVars;
@@ -131,7 +132,7 @@ public:
 
 	auto call_stack_path_to_call_frame_count(HspObjectPath::CallStack const& path) const -> std::size_t;
 
-	auto call_stack_path_to_call_frame_id_at(HspObjectPath::CallStack const& path, std::size_t call_frame_index) const -> std::optional<std::size_t>;
+	auto call_stack_path_to_call_frame_key_at(HspObjectPath::CallStack const& path, std::size_t call_frame_index) const -> std::optional<WcCallFrameKey>;
 
 	auto call_frame_path_to_name(HspObjectPath::CallFrame const& path) const -> std::optional<Utf8String>;
 

--- a/src/knowbug_core/HspObjects.h
+++ b/src/knowbug_core/HspObjects.h
@@ -88,6 +88,8 @@ public:
 
 	auto static_var_path_to_metadata(HspObjectPath::StaticVar const& path) -> HspVarMetadata;
 
+	auto element_path_is_alive(HspObjectPath::Element const& path) const->bool;
+
 	auto element_path_to_child_count(HspObjectPath::Element const& path) const -> std::size_t;
 
 	auto element_path_to_child_at(HspObjectPath::Element const& path, std::size_t child_index) const -> std::shared_ptr<HspObjectPath const>;
@@ -135,6 +137,8 @@ public:
 	auto call_stack_path_to_call_frame_key_at(HspObjectPath::CallStack const& path, std::size_t call_frame_index) const -> std::optional<WcCallFrameKey>;
 
 	auto call_frame_path_to_name(HspObjectPath::CallFrame const& path) const -> std::optional<Utf8String>;
+
+	auto call_frame_path_is_alive(HspObjectPath::CallFrame const& path) const -> bool;
 
 	auto call_frame_path_to_child_count(HspObjectPath::CallFrame const& path) const -> std::size_t;
 


### PR DESCRIPTION
パスが有効か否かの判定処理を高速化します。

現在は線型探索ですが、ほとんどのケースで O(1) にできるはずです。(特に配列の要素)