### PR TITLE
knowbug ウィンドウを HSP ウィンドウより背面に表示する

### DIFF
--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -481,8 +481,11 @@ void Dialog::createMain(hpiutil::DInfo const& debug_segment, HspObjects& objects
 
 	for ( auto&& hwnd : windowHandles() ) {
 		UpdateWindow(hwnd);
-		ShowWindow(hwnd, SW_SHOW);
+		ShowWindow(hwnd, SW_SHOWNOACTIVATE);
 	}
+
+	// 他のウィンドウより後ろに移動する (Z オーダーを下げる)
+	SetWindowPos(hViewWnd.get(), HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 
 void Dialog::destroyMain()


### PR DESCRIPTION
初期表示時、knowbug のウィンドウが HSP のウィンドウより前に来ない方が嬉しいです。

refs #32 