### PR TITLE
str 型がバイナリか検査する

### DIFF
--- a/src/knowbug_core/HspObjectPath.cpp
+++ b/src/knowbug_core/HspObjectPath.cpp
@@ -312,7 +312,7 @@ auto HspObjectPath::as_str() const -> HspObjectPath::Str const& {
 	return *(HspObjectPath::Str const*)this;
 }
 
-auto HspObjectPath::Str::value(HspObjects& objects) const -> Utf8String {
+auto HspObjectPath::Str::value(HspObjects& objects) const -> HspStr {
 	return objects.str_path_to_value(*this);
 }
 

--- a/src/knowbug_core/HspObjectPath.h
+++ b/src/knowbug_core/HspObjectPath.h
@@ -524,7 +524,7 @@ public:
 		return to_owned(as_utf8(u8"str"));
 	}
 
-	auto value(HspObjects& objects) const -> Utf8String;
+	auto value(HspObjects& objects) const -> HspStr;
 };
 
 // -----------------------------------------------

--- a/src/knowbug_core/HspObjects.h
+++ b/src/knowbug_core/HspObjects.h
@@ -110,7 +110,7 @@ public:
 
 	auto label_path_to_static_label_id(HspObjectPath::Label const& path) const -> std::optional<std::size_t>;
 
-	auto str_path_to_value(HspObjectPath::Str const& path) const->Utf8String;
+	auto str_path_to_value(HspObjectPath::Str const& path) const->HspStr;
 
 	auto double_path_to_value(HspObjectPath::Double const& path) const->HspDouble;
 

--- a/src/knowbug_core/hsx.h
+++ b/src/knowbug_core/hsx.h
@@ -10,9 +10,17 @@
 #include "memory_view.h"
 
 namespace hsp_sdk_ext {
+	// HSP の文字列データ。
+	// 1. str 型はランタイムエンコーディング (shift_jis/utf-8) の文字列だけでなく、
+	// 他のエンコーディングの文字列や任意のバイナリを格納するのにも使われることがたまにある。
+	// 特に、null 終端とは限らない点に注意。std::strlen などの null 終端を前提とする関数に渡してはいけない。
+	// 2. 変数や refstr に由来する文字列データはバッファサイズが容易に取得できる。
+	// str 引数の文字列データはバッファサイズを取得できないが、null 終端が保証されている。
+	using HspStr = Slice<char>;
+
 	extern auto data_from_label(HspLabel const* ptr)->HspData;
 
-	extern auto data_from_str(char const* value)->HspData;
+	extern auto data_from_str(char const* ptr)->HspData;
 
 	extern auto data_from_double(HspDouble const* ptr)->HspData;
 
@@ -37,6 +45,8 @@ namespace hsp_sdk_ext {
 	extern auto element_to_data(PVal const* pval, std::size_t aptr, HSPCTX const* ctx)->std::optional<HspData>;
 
 	extern auto element_to_memory_block(PVal const* pval, std::size_t aptr, HSPCTX const* ctx)->MemoryView;
+
+	extern auto element_to_str(PVal const* pval, std::size_t aptr, HSPCTX const* ctx)->std::optional<HspStr>;
 
 	extern auto flex_is_nullmod(FlexValue const* flex) -> bool;
 
@@ -81,6 +91,8 @@ namespace hsp_sdk_ext {
 	extern auto param_data_to_mp_mod_var(HspParamType param_type, void const* data)->std::optional<MPModVarData const*>;
 
 	extern auto param_data_to_data(HspParamData const& param_data)->std::optional<HspData>;
+
+	extern auto param_data_to_str(HspParamData const& param_data)->std::optional<HspStr>;
 
 	extern auto param_stack_to_param_data_count(HspParamStack const& param_stack)->std::size_t;
 
@@ -136,7 +148,7 @@ namespace hsp_sdk_ext {
 
 	extern auto system_var_sublev(HSPCTX const* ctx)->HspInt const*;
 
-	extern auto system_var_refstr(HSPCTX const* ctx)->Slice<char>;
+	extern auto system_var_refstr(HSPCTX const* ctx)->HspStr;
 
 	extern auto system_var_refdval(HSPCTX const* ctx)->HspDouble const*;
 

--- a/src/knowbug_core/hsx_data.cpp
+++ b/src/knowbug_core/hsx_data.cpp
@@ -6,8 +6,8 @@ namespace hsp_sdk_ext {
 		return HspData{ HspType::Label, (PDAT const*)ptr };
 	}
 
-	auto data_from_str(char const* value) -> HspData {
-		return HspData{ HspType::Str, (PDAT const*)value };
+	auto data_from_str(char const* ptr) -> HspData {
+		return HspData{ HspType::Str, (PDAT const*)ptr };
 	}
 
 	auto data_from_double(HspDouble const* ptr) -> HspData {

--- a/src/knowbug_core/hsx_element.cpp
+++ b/src/knowbug_core/hsx_element.cpp
@@ -66,4 +66,11 @@ namespace hsp_sdk_ext {
 
 		return element_data_to_memory_block(pval, data_opt->ptr(), ctx);
 	}
+
+	auto element_to_str(PVal const* pval, std::size_t aptr, HSPCTX const* ctx) -> std::optional<HspStr> {
+		assert(pval != nullptr);
+
+		auto&& memory = element_to_memory_block(pval, aptr, ctx);
+		return Slice<char>{ (char const*)memory.data(), memory.size() };
+	}
 }

--- a/src/knowbug_core/hsx_param_data.cpp
+++ b/src/knowbug_core/hsx_param_data.cpp
@@ -98,4 +98,28 @@ namespace hsp_sdk_ext {
 			return std::nullopt;
 		}
 	}
+
+	auto param_data_to_str(HspParamData const& param_data) -> std::optional<HspStr> {
+		if (!param_data.safety()) {
+			return std::nullopt;
+		}
+
+		switch (param_data_to_type(param_data)) {
+		case MPTYPE_LOCALSTRING: {
+			auto str = UNSAFE(*(char const**)param_data.ptr());
+			if (!str) {
+				assert(false && u8"str param must not be null");
+				return std::nullopt;
+			}
+
+			// NOTE: str 引数の値は必ず NULL 終端されている。hsp3_code.cpp/code_expandstruct を参照。
+			// FIXME: 値は不変なので、文字数はキャッシュできる。キャッシュを削除するタイミングが微妙。
+			auto size = std::strlen(str) + 1;
+
+			return std::make_optional(Slice<char>{ str, size });
+		}
+		default:
+			return std::nullopt;
+		}
+	}
 }

--- a/src/knowbug_core/knowbug_core.vcxproj.filters
+++ b/src/knowbug_core/knowbug_core.vcxproj.filters
@@ -212,9 +212,6 @@
     <ClCompile Include="hsx_static_vars.cpp">
       <Filter>hsp-sdk-ext</Filter>
     </ClCompile>
-    <ClCompile Include="hsx_element.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
     <ClCompile Include="hsx_object_temps.cpp">
       <Filter>hsp-sdk-ext</Filter>
     </ClCompile>
@@ -240,6 +237,9 @@
       <Filter>hsp-sdk-ext</Filter>
     </ClCompile>
     <ClCompile Include="hsx_debug_segment.cpp">
+      <Filter>hsp-sdk-ext</Filter>
+    </ClCompile>
+    <ClCompile Include="hsx_element.cpp">
       <Filter>hsp-sdk-ext</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
str 型の値は peek/poke などで好きに書き換えられるので、NULL 文字で終端されていないことがあります。かなりのレアケースですが、念のため対処します。

- 文字列はバッファサイズとペアで持ち運ぶようにして、範囲外にアクセスしないようにする
- 明らかな制御文字が含まれているデータは、文字列として処理しないようにする