### PR TITLE
fix: WM_COPYDATA の wparam を適切に設定する

### DIFF
--- a/src/knowbug_client/kc_app.hsp
+++ b/src/knowbug_client/kc_app.hsp
@@ -184,14 +184,14 @@
 	app_config_load
 	app_ui_init
 
-	infra_connect_server
+	infra_connect_server s_main_window_hwnd
 	if stat == false {
 		app_did_disconnect
 		return
 	}
 
 	logmes "send hello"
-	infra_send_hello s_main_window_hwnd
+	infra_send_hello
 	return
 
 #deffunc app_init_globals

--- a/src/knowbug_client/kc_main.hsp
+++ b/src/knowbug_client/kc_main.hsp
@@ -9,8 +9,10 @@
 
 ; サーバーとの接続を確立する
 ; (サーバーのウィンドウハンドルをコマンドライン経由で受け取る。サーバーへのメッセージを送るときは、このハンドルに送る)
-#deffunc infra_connect_server \
+#deffunc infra_connect_server int client_hwnd, \
 	local cmdline, local args, local server_hwnd_arg
+
+	s_client_hwnd = client_hwnd
 
 	sdim s_input_buf, 0x8000
 
@@ -74,6 +76,8 @@
 #deffunc infra_send_message array keys, array values, array value_lens, int count, \
 	local message, local message_len, local copydata
 
+	assert s_client_hwnd != 0
+
 	if s_server_hwnd == 0 {
 		return
 	}
@@ -88,14 +92,16 @@
 	dim copydata, 4 * 3
 	copydata = 0, message_len, varptr(message)
 
-	sendmsg s_server_hwnd, WM_COPYDATA, 0, varptr(copydata)
+	sendmsg s_server_hwnd, WM_COPYDATA, s_client_hwnd, varptr(copydata)
 	return
 
-#deffunc infra_send_hello int client_hwnd, \
+#deffunc infra_send_hello \
 	local keys, local values, local value_lens, local count
 
+	assert s_client_hwnd != NULL
+
 	assoc_set_str keys, values, value_lens, count, "method", "initialize_notification"
-	assoc_set_str keys, values, value_lens, count, "client_hwnd", str(client_hwnd)
+	assoc_set_str keys, values, value_lens, count, "client_hwnd", str(s_client_hwnd)
 
 	infra_send_message keys, values, value_lens, count
 	return

--- a/src/knowbug_dll/knowbug_server.cpp
+++ b/src/knowbug_dll/knowbug_server.cpp
@@ -1085,7 +1085,12 @@ private:
 		auto copydata = COPYDATASTRUCT{};
 		copydata.cbData = (DWORD)text.size();
 		copydata.lpData = text.data();
-		SendMessage(client_hwnd_, WM_COPYDATA, 0, (LPARAM)&copydata);
+
+		// この関数は start の処理後にだけ呼ばれる
+		assert(hidden_window_opt_.has_value());
+		auto server_hwnd = HWND{ hidden_window_opt_->get() };
+
+		SendMessage(client_hwnd_, WM_COPYDATA, (WPARAM)server_hwnd, (LPARAM)&copydata);
 	}
 
 	void send_message(std::u8string_view method) {


### PR DESCRIPTION
[WM_COPYDATA](https://learn.microsoft.com/ja-jp/windows/win32/dataxchg/wm-copydata) のドキュメントによると WPARAM にはデータを渡すウィンドウのハンドルを指定する必要があります