### PR TITLE
fix: 変数の一部が表示されない不具合を修正 (refs #117)

### DIFF
--- a/src/knowbug_core/hsp_objects.cpp
+++ b/src/knowbug_core/hsp_objects.cpp
@@ -15,9 +15,6 @@ static auto const MIN_DEPTH = std::size_t{};
 // 再帰深度の最大値 (スタックオーバーフローを防ぐため)
 static auto const MAX_DEPTH = std::size_t{ 32 };
 
-// ビジュアルツリーの子要素数の最大値
-static constexpr auto MAX_VISUAL_CHILD_COUNT = HspObjectPath::Group::MAX_CHILD_COUNT;
-
 static auto param_path_to_param_data(HspObjectPath::Param const& path, std::size_t depth, HSPCTX const* ctx) -> std::optional<HsxParamData>;
 
 static auto const GLOBAL_MODULE_ID = std::size_t{ 0 };
@@ -148,7 +145,7 @@ static auto path_to_visual_child_count_default(HspObjectPath const& path, HspObj
 		return group_count;
 	}
 
-	return std::min(n, MAX_VISUAL_CHILD_COUNT);
+	return n;
 }
 
 static auto path_to_visual_child_at_default(HspObjectPath const& path, std::size_t child_index, HspObjects& objects) -> std::optional<std::shared_ptr<HspObjectPath const>> {


### PR DESCRIPTION
- グループノード機能の不具合でした
     - (#39)
- もとのコードはノードの子要素が一定未満 (200 未満) の場合に、表示する子要素数を 100 個までに制限していました
    - コミットログやコードをみても制限する必要性は分かりませんでした