### PR TITLE
タイトルバーにランタイムの種類を表示する

### DIFF
--- a/src/knowbug_dll/knowbug_server.cpp
+++ b/src/knowbug_dll/knowbug_server.cpp
@@ -1096,7 +1096,7 @@ private:
 	void send_initialized_event() {
 		auto message = KnowbugMessage::new_with_method(std::u8string{ u8"initialized_event" });
 
-		message.insert(std::u8string{ u8"version" }, std::u8string{ as_utf8(KNOWBUG_VERSION) });
+		message.insert(std::u8string{ u8"version" }, knowbug_version());
 
 		send_message(message);
 	}


### PR DESCRIPTION
タイトルにランタイム情報 (UTF-8, x64 かどうか) を表示する機能 (cc64b77) がいつのまにか消えていたので、修正します